### PR TITLE
rename property

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "dependencyDashboardAutoclose": true,
-  "platformAutomerge": true,
   "extends": [
     "config:base",
     ":maintainLockFilesWeekly",
@@ -15,10 +14,10 @@
     ":prHourlyLimitNone",
     "helpers:pinGitHubActionDigests"
   ],
+  "internalChecksFilter": "strict",
   "lockFileMaintenance": {
     "automerge": true
   },
-  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "automerge": true,
@@ -27,7 +26,7 @@
     },
     {
       "description": "v prefix workaround for action updates",
-      "extractVersion": "^(?<version>v\\d+\\.\\d+\\.\\d+)$",
+      "extractVersion": "^(?<version>v\\d+(?:\\.\\d+){0,2})$",
       "matchDepTypes": ["action"],
       "versioning": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$"
     },
@@ -37,6 +36,7 @@
       "matchUpdateTypes": ["major"]
     }
   ],
+  "platformAutomerge": true,
   "rangeStrategy": "bump",
   "rollbackPrs": true
 }

--- a/rust/updateChannelInRustToolchainToml.json
+++ b/rust/updateChannelInRustToolchainToml.json
@@ -4,8 +4,8 @@
   "packageRules": [
     {
       "commitMessageTopic": "Rust",
-      "matchManagers": ["regex"],
-      "matchPackageNames": ["rust"]
+      "matchDepNames": ["rust"],
+      "matchManagers": ["regex"]
     }
   ],
   "regexManagers": [

--- a/rust/updateRustVersionInCargoToml.json
+++ b/rust/updateRustVersionInCargoToml.json
@@ -4,8 +4,8 @@
   "packageRules": [
     {
       "commitMessageTopic": "Rust",
-      "matchManagers": ["regex"],
-      "matchPackageNames": ["rust"]
+      "matchDepNames": ["rust"],
+      "matchManagers": ["regex"]
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
- fix: allow v1 like versions that don't have v1.0.0 versions
- fix: rename matchPackageNames to matchDepNames as per docs
